### PR TITLE
fix(blog): correct date for Day 45 entry to 2025-09-27

### DIFF
--- a/src/content/blog/day45.mdx
+++ b/src/content/blog/day45.mdx
@@ -1,7 +1,7 @@
 ---
 title: 踏入自媒體的 30 天 - Day 45
 author: Tomzyang
-date: 2026-09-27
+date: 2025-09-27
 tags: ['astro', '30days', 'ai', 'successes']
 draft: false
 summary: 'IST → HBE 1,151 公里：凌晨抵達亞歷山卓，機場過夜後入住 IHG Crowne Plaza，規劃港邊半日遊，繼續土耳其航空百萬哩程挑戰。'


### PR DESCRIPTION
# Summary
This pull request makes a small correction to the `src/content/blog/day45.mdx` file, updating the date metadata to the correct year. No other changes were made.

* Changed the `date` field from `2026-09-27` to `2025-09-27` in the blog post metadata.